### PR TITLE
Issue/26 댓글 수정 기능 추가

### DIFF
--- a/src/main/java/com/sparta/i_am_delivery/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/i_am_delivery/comment/controller/CommentController.java
@@ -6,11 +6,14 @@ import com.sparta.i_am_delivery.comment.dto.response.CommentCreationResponseDto;
 import com.sparta.i_am_delivery.comment.service.CommentService;
 import com.sparta.i_am_delivery.common.annotation.AuthUser;
 import com.sparta.i_am_delivery.domain.user.entity.User;
+import com.sparta.i_am_delivery.review.dto.response.CommentUpdateResponseDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,5 +34,13 @@ public class CommentController {
         commentRequestDto);
 
     return ResponseEntity.status(HttpStatus.CREATED).body(comment);
+  }
+
+  @PutMapping("/comments/{id}")
+  public ResponseEntity<CommentUpdateResponseDto> updateComment(@PathVariable Long id,
+      @AuthUser User user, @RequestBody @Valid
+  CommentRequestDto commentRequestDto) {
+    CommentUpdateResponseDto comment = commentService.updateComment(id, user, commentRequestDto);
+    return ResponseEntity.status(HttpStatus.OK).body(comment);
   }
 }

--- a/src/main/java/com/sparta/i_am_delivery/comment/dto/request/CommentRequestDto.java
+++ b/src/main/java/com/sparta/i_am_delivery/comment/dto/request/CommentRequestDto.java
@@ -7,5 +7,5 @@ import lombok.Getter;
 public class CommentRequestDto {
 
   @NotNull(message = "내용을 입력해주세요")
-  private String comment;
+  private String content;
 }

--- a/src/main/java/com/sparta/i_am_delivery/comment/service/CommentService.java
+++ b/src/main/java/com/sparta/i_am_delivery/comment/service/CommentService.java
@@ -11,8 +11,10 @@ import com.sparta.i_am_delivery.domain.review.repository.ReviewRepository;
 import com.sparta.i_am_delivery.domain.store.entity.Store;
 import com.sparta.i_am_delivery.domain.store.repository.StoreRepository;
 import com.sparta.i_am_delivery.domain.user.entity.User;
+import com.sparta.i_am_delivery.review.dto.response.CommentUpdateResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -32,16 +34,28 @@ public class CommentService {
     Review review = reviewRepository.findById(reviewId)
         .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
 
-    // 이미 해당 유저가 이미 댓글을 작성했는지 확인
+    // 해당 유저가 이미 댓글을 작성했는지 확인
     boolean commentExists = commentRepository.existsByReviewIdAndUserId(reviewId, user.getId());
     if (commentExists) {
       throw new CustomException(ErrorCode.COMMENT_DUPLICATE);
     }
 
     Comment comment = new Comment();
-    comment.createComment(store, review, user, commentRequestDto.getComment());
+    comment.createComment(store, review, user, commentRequestDto.getContent());
     commentRepository.save(comment);
 
     return new CommentCreationResponseDto(comment);
+  }
+
+  @Transactional
+  public CommentUpdateResponseDto updateComment(Long id, User user,
+      CommentRequestDto commentRequestDto) {
+
+    // 리뷰 존재 유무 + 작성자 확인
+    Comment comment = commentRepository.findByIdAndUserId(id, user.getId())
+        .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+    comment.updateComment(commentRequestDto);
+    return new CommentUpdateResponseDto(comment);
   }
 }

--- a/src/main/java/com/sparta/i_am_delivery/domain/comment/entity/Comment.java
+++ b/src/main/java/com/sparta/i_am_delivery/domain/comment/entity/Comment.java
@@ -1,5 +1,6 @@
 package com.sparta.i_am_delivery.domain.comment.entity;
 
+import com.sparta.i_am_delivery.comment.dto.request.CommentRequestDto;
 import com.sparta.i_am_delivery.common.entity.TimeStamped;
 import com.sparta.i_am_delivery.domain.review.entity.Review;
 import com.sparta.i_am_delivery.domain.store.entity.Store;
@@ -47,5 +48,9 @@ public class Comment extends TimeStamped {
     this.review = review;
     this.user = user;
     this.content = comment;
+  }
+
+  public void updateComment(CommentRequestDto commentRequestDto) {
+    this.content = commentRequestDto.getContent();
   }
 }

--- a/src/main/java/com/sparta/i_am_delivery/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sparta/i_am_delivery/domain/comment/repository/CommentRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+  Optional<Comment> findByIdAndUserId(Long reviewId, Long userId);
+
   boolean existsByReviewIdAndUserId(Long reviewId, Long userId);
 
   Optional<Comment> findByReviewId(Long reviewId);

--- a/src/main/java/com/sparta/i_am_delivery/review/dto/response/CommentUpdateResponseDto.java
+++ b/src/main/java/com/sparta/i_am_delivery/review/dto/response/CommentUpdateResponseDto.java
@@ -1,0 +1,19 @@
+package com.sparta.i_am_delivery.review.dto.response;
+
+
+import com.sparta.i_am_delivery.domain.comment.entity.Comment;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentUpdateResponseDto {
+
+  private Long id;
+  private String content;
+
+  public CommentUpdateResponseDto(Comment comment) {
+    this.id = comment.getId();
+    this.content = comment.getContent();
+  }
+}


### PR DESCRIPTION
- 제목 : Issue/26 댓글 수정 기능 추가

## 🔘Part

- 댓글 기능 파트

  <br/>

## 🔎 작업 내용

- 댓글 수정 기능 추가 : 댓글을 수정할 수 있는 기능이 추가되었습니다.
- 유효성 검증 추가 : 댓글 수정 시, 기존 댓글 작성자와 수정 요청자의 id가 일치하는지 확인하는 유효성 검증을 추가하여, 작성자만 수정할 수 있도록 보장했습니다. 
- 댓글 존재 유무 및 작성자 확인 : 댓글 존재 여부를 확인할 때, 작성자 확인도 함께 이루어지도록 쿼리 최적화가 적용되었습니다.

  <br/>

## 🔧 앞으로의 과제

- 댓글 삭제 기능 작업 예정

  <br/>