### PR TITLE
Issue/27 댓글 삭제 기능 추가

### DIFF
--- a/src/main/java/com/sparta/i_am_delivery/comment/controller/CommentController.java
+++ b/src/main/java/com/sparta/i_am_delivery/comment/controller/CommentController.java
@@ -11,6 +11,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -42,5 +43,12 @@ public class CommentController {
   CommentRequestDto commentRequestDto) {
     CommentUpdateResponseDto comment = commentService.updateComment(id, user, commentRequestDto);
     return ResponseEntity.status(HttpStatus.OK).body(comment);
+  }
+
+  @DeleteMapping("/comments/{id}")
+  public ResponseEntity<Void> deleteComment(@PathVariable Long storeId, @PathVariable Long id,
+      @AuthUser User user) {
+    commentService.deleteComment(storeId, id, user);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/sparta/i_am_delivery/comment/service/CommentService.java
+++ b/src/main/java/com/sparta/i_am_delivery/comment/service/CommentService.java
@@ -58,4 +58,18 @@ public class CommentService {
     comment.updateComment(commentRequestDto);
     return new CommentUpdateResponseDto(comment);
   }
+
+  @Transactional
+  public void deleteComment(Long storeId, Long id, User user) {
+    Comment comment = commentRepository.findById(id)
+        .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+    if (!comment.getStore().getId().equals(storeId)) {
+      throw new CustomException(ErrorCode.COMMENT_NOT_BELONG_TO_STORE);
+    }
+    if (!comment.getUser().getId().equals(user.getId())) {
+      throw new CustomException(ErrorCode.NOT_AUTHOR_OF_COMMENT);
+    }
+    commentRepository.delete(comment);
+  }
 }

--- a/src/main/java/com/sparta/i_am_delivery/common/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/i_am_delivery/common/exception/ErrorCode.java
@@ -71,6 +71,9 @@ public enum ErrorCode {
   COMMENT_NOT_FOUND("COMMENT_NOT_FOUND", "댓글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   NO_COMMENT_PERMISSION("NO_COMMENT_PERMISSION", "댓글 수정/삭제 권한이 없습니다.", HttpStatus.FORBIDDEN),
   COMMENT_DUPLICATE("DUPLICATE_COMMENT", "이미 작성하셨습니다.", HttpStatus.BAD_REQUEST),
+  COMMENT_NOT_BELONG_TO_STORE("COMMENT_NOT_BELONG_TO_STORE", "해당 댓글이 가게에 속해있지않습니다",
+      HttpStatus.BAD_REQUEST),
+  NOT_AUTHOR_OF_COMMENT("NOT_AUTHOR_OF_COMMENT", "해당 댓글 작성자가 아닙니다.", HttpStatus.UNAUTHORIZED),
 
   // 즐겨찾기 관련 에러 코드
   LIKE_NOT_FOUND("LIKE_NOT_FOUND", "즐겨찾기를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/main/java/com/sparta/i_am_delivery/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/i_am_delivery/review/service/ReviewService.java
@@ -114,7 +114,7 @@ public class ReviewService {
         .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
 
     if (!review.getStore().getId().equals(storeId)) {
-      throw new CustomException(ErrorCode.REVIEW_NOT_BELONG_TO_STORE);
+      throw new CustomException(ErrorCode.COMMENT_NOT_BELONG_TO_STORE);
     }
     if (!review.getUser().getId().equals(user.getId())) {
       throw new CustomException(ErrorCode.NOT_AUTHOR_OF_REVIEW);


### PR DESCRIPTION
- 제목 : Issue/27 댓글 삭제 기능 추가

## 🔘Part

- 댓글 기능 파트

  <br/>

## 🔎 작업 내용

- 댓글 삭제 기능 추가 : 댓글을 삭제할 수 있는 기능이 추가되었습니다.
- 유효성 검증 추가 : 댓글 삭제 시, 기존 댓글 작성자와 삭제 요청자의 id가 일치하는지 확인하는 유효성 검증을 추가하여, 작성자만 수정할 수 있도록 보장했습니다.

  <br/>

## 🔧 앞으로의 과제

- 통합 테스트 준비 예정

  <br/>